### PR TITLE
Feature : 다른 멤버 마이페이지 조회 / Fix  프로필 수정 시 닉네임 중복 체크

### DIFF
--- a/src/main/java/com/pair/website/controller/MemberController.java
+++ b/src/main/java/com/pair/website/controller/MemberController.java
@@ -51,4 +51,9 @@ public class MemberController {
 
         return memberService.getProfile(member.getId());
     }
+
+    @GetMapping("/api/member/detail/{nickname}")
+    public ResponseEntity<?> getOtherProfile(@PathVariable String nickname){
+        return memberService.getOtherProfile(nickname);
+    }
 }


### PR DESCRIPTION
## :: PR 타입

- [x]  기능 추가
- [ ]  리팩토링
- [x]  버그 수정

## :: 구현
- 다른 멤버 마이페이지 조회

## :: 수정
- 프로필 수정 시 닉네임 중복 체크 

## :: 특이 사항

## :: 질문
- 다른 멤버 마이페이지 조회 시 기존에 있는 마이페이지 API를 수정해서 합치는게 좋을까요 아니면 그냥 따로 두는게 좋을까요?
- 다른 멤버 프로필 조회는 로그인 없이도 조회 가능하도록 하는게 좋을까요?