### PR TITLE
[fix] 닉네임 중복 오류 / 이미지 null 처리

### DIFF
--- a/src/main/java/com/pair/website/controller/MemberController.java
+++ b/src/main/java/com/pair/website/controller/MemberController.java
@@ -51,7 +51,7 @@ public class MemberController {
      * @return BaseResponseDto<MemberResponseDto> 200 OK, 수정된 회원정보 및 작성한 게시물
      */
     @PutMapping("/api/member/update")
-    public BaseResponseDto<?> updateProfile(@RequestPart ProfileRequestDto requestDto, HttpServletRequest request, @RequestPart(value = "image") MultipartFile image) throws IOException {
+    public BaseResponseDto<?> updateProfile(@RequestPart ProfileRequestDto requestDto, HttpServletRequest request, @RequestPart(value = "image",required = false) MultipartFile image) throws IOException {
         BaseResponseDto<?> result = publicMethod.checkLogin(request);
         if (!result.isSuccess()) return result;
         Member member = (Member) result.getData();

--- a/src/main/java/com/pair/website/service/MemberService.java
+++ b/src/main/java/com/pair/website/service/MemberService.java
@@ -151,11 +151,12 @@ public class MemberService {
         );
 
 
-        if (member.getNickname() != requestDto.getNickname() & checkNickname(requestDto.getNickname()) != null)
+        if (!member.getNickname().equals(requestDto.getNickname())  && checkNickname(requestDto.getNickname()) != null)
             return BaseResponseDto.fail("DUPLICATED_NICKNAME", "중복된 닉네임 입니다.");
-
         String storedFileName = null;
-        if (!image.isEmpty()) {
+        if(image == null)
+            storedFileName = member.getProfileImage();
+        else if (!image.isEmpty()) {
             storedFileName = awsS3Uploader.upload(image, "images");
             // member.setProfileImage(storedFileName);
         }


### PR DESCRIPTION
## :: PR 타입

- [ ]  기능 추가
- [ ]  리팩토링
- [x]  버그 수정

## :: 수정
- 닉네임 중복 오류 수정 (문자열 처리라서 != 대신 equals로 바꿔서 해결)
- S3 이미지 null값 오류 처리 (Controller에 required = false 추가)